### PR TITLE
Make the package working on Windows 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-device-emulator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "cloud-device-emulator",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "4.14.1",
     "express-handlebars": "3.0.0",
     "express-validator": "3.1.3",
+    "osenv": "0.1.4",
     "socket.io": "1.7.3",
     "uuid": "3.0.1"
   },

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,7 +4,7 @@ const path = require('path');
 const packageName = "cloud-device-emulator";
 
 const winLogFilesLocation = path.join(process.env.APPDATA || "", packageName);
-const unixLogFilesLocation = path.join(process.env.HOME, ".local", "share", packageName);
+const unixLogFilesLocation = path.join(osenv.home(), ".local", "share", packageName);
 const logsDir = process.platform === "win32" ? winLogFilesLocation : unixLogFilesLocation;
 const statusFileDir = path.join(logsDir, "health");
 


### PR DESCRIPTION
Windows does not have "HOME" environment variable, so requiring the "constants" file throws error: "Path must be a string, received undefined".
Use osenv package, which we are using in CLI, so that's the correct way to get the path on non-windows platforms.