### PR TITLE
Use websockets for device detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const DeviceEmitter = require('./src/device-emitter');
 const DeviceManager = require('./src/device-manager');
 const deviceEmitterInstance = new DeviceEmitter();
-const deviceManager = new DeviceManager();
+const deviceManager = new DeviceManager(deviceEmitterInstance);
 
 module.exports = {
     getSeverAddress: deviceEmitterInstance.getSeverAddress.bind(deviceEmitterInstance),

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -1,6 +1,7 @@
 interface CloudDeviceEmitter {
 	on(event: string, listener: Function): this;
 	getCurrentlyAttachedDevices(): IAttachedDevices;
+	dispose(): void;
 }
 
 interface IAttachedDevices {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-device-emulator",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "cloud-device-emulator",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-device-emulator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "cloud-device-emulator",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,9 +16,12 @@
     "express-validator": "3.1.3",
     "osenv": "0.1.4",
     "socket.io": "1.7.3",
+    "socket.io-client": "2.0.2",
     "uuid": "3.0.1"
   },
   "devDependencies": {
+    "@types/socket.io": "^1.4.29",
+    "@types/socket.io-client": "^1.4.29",
     "@types/uuid": "2.0.29"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
     "express": "4.14.1",
     "express-handlebars": "3.0.0",
     "express-validator": "3.1.3",
+    "lodash": "4.17.4",
     "osenv": "0.1.4",
     "socket.io": "1.7.3",
     "socket.io-client": "2.0.2",
     "uuid": "3.0.1"
   },
   "devDependencies": {
-    "@types/socket.io": "^1.4.29",
-    "@types/socket.io-client": "^1.4.29",
+    "@types/lodash": "4.14.65",
+    "@types/socket.io": "1.4.29",
+    "@types/socket.io-client": "1.4.29",
     "@types/uuid": "2.0.29"
   }
 }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -92,6 +92,7 @@ module.exports = {
     eventNames: {
         deviceFound: "deviceFound",
         deviceLost: "deviceLost",
+        deviceEmitter: "deviceEmitter",
         data: "data",
         error: "error",
         end: "end"

--- a/src/device-emitter.js
+++ b/src/device-emitter.js
@@ -50,14 +50,14 @@ class DeviceEmitter extends EventEmitter {
                         });
 
                         const id = uuid.v4();
-                        const client = socketClient(`http://${constants.server.host}:${this.port}`);
-                        client.on(constants.eventNames.deviceFound, device => {
+                        this.client = socketClient(`http://${constants.server.host}:${this.port}`);
+                        this.client.on(constants.eventNames.deviceFound, device => {
                             this.addDevice(device);
                         });
-                        client.on(constants.eventNames.deviceLost, deviceIdentifier => {
+                        this.client.on(constants.eventNames.deviceLost, deviceIdentifier => {
                             this.removeDevice(deviceIdentifier);
                         });
-                        client.emit(constants.eventNames.deviceEmitter, id);
+                        this.client.emit(constants.eventNames.deviceEmitter, id);
                     }
                 }, 400);
             });
@@ -109,6 +109,10 @@ class DeviceEmitter extends EventEmitter {
                     });
                 });
             }));
+    }
+
+    dispose() {
+        this.client.close();
     }
 
     _raiseOnDeviceFound(device) {

--- a/src/device-emitter.js
+++ b/src/device-emitter.js
@@ -7,6 +7,8 @@ const path = require("path");
 const fs = require("fs");
 const child_process = require("child_process");
 const http = require("http");
+const socketClient = require('socket.io-client');
+const uuid = require('uuid');
 
 let instance = null;
 
@@ -46,6 +48,16 @@ class DeviceEmitter extends EventEmitter {
                                 });
                             });
                         });
+
+                        const id = uuid.v4();
+                        const client = socketClient(`http://${constants.server.host}:${this.port}`);
+                        client.on(constants.eventNames.deviceFound, device => {
+                            this.addDevice(device);
+                        });
+                        client.on(constants.eventNames.deviceLost, deviceIdentifier => {
+                            this.removeDevice(deviceIdentifier);
+                        });
+                        client.emit(constants.eventNames.deviceEmitter, id);
                     }
                 }, 400);
             });

--- a/src/device-manager.js
+++ b/src/device-manager.js
@@ -3,8 +3,8 @@ const constants = require('./common/constants');
 const DeviceEmitter = require('./device-emitter');
 
 class DeviceManager {
-    constructor() {
-        this.deviceEmitterInstance = new DeviceEmitter();
+    constructor(deviceEmitterInstance) {
+        this.deviceEmitterInstance = deviceEmitterInstance;
     }
 
     refresh(deviceIdentifier) {


### PR DESCRIPTION
Decouple server from device emitter - they cannot require one another because the server is a detached child process.
Use websockets instead.

Ping @rosen-vladimirov @TomaNikolov 