### PR TITLE
Use node to start server explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-device-emulator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "cloud-device-emulator",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/device-emitter.js
+++ b/src/device-emitter.js
@@ -23,7 +23,7 @@ class DeviceEmitter extends EventEmitter {
             const out = fs.openSync(outFileName, 'a');
             const err = fs.openSync(path.join(constants.logFilesLocation.logsDir, `${fileName}.err`), 'a');
             this.startServerPromise = new Promise((resolve, reject) => {
-                child_process.spawn(process.argv[0], [path.join(__dirname, "server-launcher.js")], { detached: true, stdio: ['ignore', out, err] }).unref();
+                child_process.spawn("node", [path.join(__dirname, "server-launcher.js")], { detached: true, stdio: ['ignore', out, err] }).unref();
                 const intervalHandle = setInterval(() => {
                     const contents = fs.readFileSync(outFileName).toString();
                     if (contents) {


### PR DESCRIPTION
Do not rely on `process.argv[0]` because it could be something funky like `Electron Helper` 💭 

Ping @rosen-vladimirov @TomaNikolov 