### PR TITLE
Dispose deviceEmitter correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-device-emulator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "cloud-device-emulator",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Do not close client if `this.client` doesn't have a value.
Do not run any logic if already disposed.

Ping @TomaNikolov @rosen-vladimirov 